### PR TITLE
add: React/Go サブモジュールを最新化する make コマンドを追加

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,19 +95,19 @@ go-db-reset:
 # ============================================================
 
 # React サブモジュールを main の最新にする
-update-react:
+submodules-update-react:
 	@echo ">>> React を main の最新に更新します"
 	cd submodules/frontend/react && git checkout main && git pull --ff-only
 	@echo "✅ React を更新しました"
 
 # Go サブモジュールを master の最新にする
-update-go:
+submodules-update-go:
 	@echo ">>> Go を master の最新に更新します"
 	cd submodules/backend/go && git checkout master && git pull --ff-only
 	@echo "✅ Go を更新しました"
 
 # React と Go を両方最新にする
-update-all: update-react update-go
+submodules-update-all: submodules-update-react submodules-update-go
 	@echo "✅ React と Go を最新に更新しました"
 
 # ============================================================

--- a/Makefile
+++ b/Makefile
@@ -88,6 +88,29 @@ go-db-reset:
 	PGPASSWORD="$${DB_PASSWORD}" psqldef -U "$${DB_USER}" -h "$${DB_HOST}" -p "$${DB_PORT}" "$${DB_NAME}" < internal/infrastructure/db/schema.sql
 
 # ============================================================
+# Submodule 最新化
+#   各サブモジュールをデフォルトブランチに切り替えて最新を取得する
+#     - React : main
+#     - Go    : master
+# ============================================================
+
+# React サブモジュールを main の最新にする
+update-react:
+	@echo ">>> React を main の最新に更新します"
+	cd submodules/frontend/react && git checkout main && git pull --ff-only
+	@echo "✅ React を更新しました"
+
+# Go サブモジュールを master の最新にする
+update-go:
+	@echo ">>> Go を master の最新に更新します"
+	cd submodules/backend/go && git checkout master && git pull --ff-only
+	@echo "✅ Go を更新しました"
+
+# React と Go を両方最新にする
+update-all: update-react update-go
+	@echo "✅ React と Go を最新に更新しました"
+
+# ============================================================
 # Nginx バックエンド切り替え
 # ============================================================
 


### PR DESCRIPTION
## 概要

React / Go サブモジュールを毎回デフォルトブランチの最新に更新する make コマンドを追加します。

## 追加コマンド

| コマンド | 動作 |
|---------|------|
| `make update-react` | React を `main` に切り替えて `git pull --ff-only` |
| `make update-go` | Go を `master` に切り替えて `git pull --ff-only` |
| `make update-all` | React と Go を両方最新化 |

## ポイント

- 各サブモジュールのデフォルトブランチ（React=`main` / Go=`master`）に `checkout` してから pull するため、作業ブランチにいても確実にデフォルトブランチの最新になる。
- `--ff-only` を付与し、fast-forward できない場合は安全に失敗させて意図しないマージを防止する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)